### PR TITLE
Fixing dear friend Patrick's formatDates function

### DIFF
--- a/web/utility/formatDates.js
+++ b/web/utility/formatDates.js
@@ -31,18 +31,18 @@ function formatDate(date) {
         date = new Date(date);
     }
     const months = [
-        "January",
-        "February",
-        "March",
-        "April",
-        "May",
-        "June",
-        "July",
-        "August",
-        "September",
-        "October",
-        "November",
-        "December",
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
     ];
 
     return months[date.getMonth()] + " " + date.getFullYear();

--- a/web/utility/formatDates.js
+++ b/web/utility/formatDates.js
@@ -18,7 +18,7 @@ export default function formatDates(a, b) {
 
     if (b) {
         let b_date = new Date(b);
-        endDateText = formatDate(b_date) + (b_date > new Date() ? " (ancitipated)" : "");
+        endDateText = formatDate(b_date) + (b_date > new Date() ? " (anticipated)" : "");
     } else {
         endDateText = "Present";
     }

--- a/web/utility/formatDates.js
+++ b/web/utility/formatDates.js
@@ -1,50 +1,49 @@
 export default function formatDates(a, b) {
-  let startDateText = "";
-  let endDateText = "";
+    let startDateText = "";
+    let endDateText = "";
 
-  if (b && !a) {
-    [a, b] = [b, a];
-  } else if (!a && !b) {
-    throw new Error("Neither date is defined.");
-  } else if (a > b) {
-    [b, a] = [a, b];
-  }
+    if (b && !a) {
+        [a, b] = [b, a];
+    } else if (!a && !b) {
+        throw new Error("Neither date is defined.");
+    } else if (a > b) {
+        [b, a] = [a, b];
+    }
 
-  if (a) {
-    startDateText = formatDate(a);
-  } else {
-    startDateText = "Ambiguous beginnings";
-  }
+    if (a) {
+        startDateText = formatDate(a);
+    } else {
+        startDateText = "Ambiguous beginnings";
+    }
 
-  if (b) {
-    let b_date = new Date(b);
-    endDateText =
-      formatDate(b_date) + (b_date > new Date() ? " (ancitipated)" : "");
-  } else {
-    endDateText = "Present";
-  }
+    if (b) {
+        let b_date = new Date(b);
+        endDateText = formatDate(b_date) + (b_date > new Date() ? " (ancitipated)" : "");
+    } else {
+        endDateText = "Present";
+    }
 
-  return startDateText + " - " + endDateText;
+    return startDateText + " - " + endDateText;
 }
 
 function formatDate(date) {
-  if (!(date instanceof Date)) {
-    date = new Date(date);
-  }
-  const months = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-  ];
+    if (!(date instanceof Date)) {
+        date = new Date(date);
+    }
+    const months = [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ];
 
-  return months[date.getMonth()] + " " + date.getFullYear();
+    return months[date.getMonth()] + " " + date.getFullYear();
 }

--- a/web/utility/formatDates.js
+++ b/web/utility/formatDates.js
@@ -1,48 +1,50 @@
-export default function formatDates(a, b, toPresent) {
-    a = new Date(a)
-    b = new Date(b)
-    let startDateText = ""
-    let endDateText = ""
-    if (b && !a) {
-        [a, b] = [b, a]
-    } else if (!a && !b) {
-        throw new Error("Neither date is defined.")
-    } else if (a > b) {
-        [b, a] = [a, b];
-    }
+export default function formatDates(a, b) {
+  let startDateText = "";
+  let endDateText = "";
 
+  if (b && !a) {
+    [a, b] = [b, a];
+  } else if (!a && !b) {
+    throw new Error("Neither date is defined.");
+  } else if (a > b) {
+    [b, a] = [a, b];
+  }
+
+  if (a) {
     startDateText = formatDate(a);
-    if (!b) {
-        if (toPresent) {
-            endDateText = "present"
-        } else {
-            endDateText = "";
-        }
-    } else {
-        endDateText = formatDate(b) + (b > new Date() ? " (ancitipated)" : "");
-    }
+  } else {
+    startDateText = "Ambiguous beginnings";
+  }
 
-    return startDateText + (endDateText ? " - " + endDateText : '');
+  if (b) {
+    let b_date = new Date(b);
+    endDateText =
+      formatDate(b_date) + (b_date > new Date() ? " (ancitipated)" : "");
+  } else {
+    endDateText = "Present";
+  }
+
+  return startDateText + " - " + endDateText;
 }
 
 function formatDate(date) {
-    if (!(date instanceof Date)) {
-        date = new Date(date);
-    }
-    const months = [
-        'January',
-        'February',
-        'March',
-        'April',
-        'May',
-        'June',
-        'July',
-        'August',
-        'September',
-        'October',
-        'November',
-        'December'
-    ]
+  if (!(date instanceof Date)) {
+    date = new Date(date);
+  }
+  const months = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
 
-    return months[date.getMonth()] + " " + date.getFullYear();
+  return months[date.getMonth()] + " " + date.getFullYear();
 }


### PR DESCRIPTION
## Description
While perusing your beautiful website I noticed your `formatDates()` function, which is called while creating your `resume` page, had some erroneous behavior. The way you handled some of the null values was incorrect and in the wrong order, because you were checking whether the result of `new Date(a)` was `null` instead of `a` itself, but `new Date(null)` returns a valid string that is timestamped at [the beginning of the "epoch"](https://www.mentalfloss.com/article/26316/why-does-my-gadget-say-its-december-31-1969). There are still some unaddressed edge cases (unimportant) but I've fixed the date formatting for you and confirmed that it works as desired on a local copy. Also removed the currently unused `toPresent` parameter. Make whatever edits you need. 

I hope you have good times in Georgia, Patrick -- miss you! ❤️

## Preview
Below are the before and after pictures (tested locally and with the data from [your API](https://sivcrl3y.api.sanity.io/v1/graphql/production/default)).

### Before
<img width="951" alt="Screen Shot 2021-10-02 at 1 32 11 AM" src="https://user-images.githubusercontent.com/45826892/135707742-9178ca75-8c9a-49d0-94ef-d66eadfe73ca.png">

### After
![Screen Shot 2021-10-02 at 2 16 57 AM](https://user-images.githubusercontent.com/45826892/135707797-49c0b3d0-dd39-407c-a932-05e003aba1f0.png)

Closes #2.